### PR TITLE
breaking: rename assets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
         run: |
           k3d image import hirosystems/stacks-devnet-api:ci -c k3d-kube
           kubectl create namespace devnet
-          kubectl create configmap stacks-devnet-api-conf --from-file=./Config.toml --namespace devnet
+          kubectl create configmap stacks-devnet-api --from-file=./Config.toml --namespace devnet
           kubectl apply -f ./templates/ci/stacks-devnet-api.template.yaml
           echo "sleep for 30 sec"
           sleep 30

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ metadata:
   name: stacks-devnet-api
   namespace: devnet
 spec:
-  serviceAccountName: stacks-devnet-api-service-account
+  serviceAccountName: stacks-devnet-api
   containers:
   - command:
     - ./stacks-devnet-api
-    name: stacks-devnet-api-container
+    name: stacks-devnet-api
 -    image: quay.io/hirosystems/stacks-devnet-api:latest
 -    imagePullPolicy: Always
 +    image: stacks-devnet-api:latest
@@ -83,9 +83,9 @@ When the service has been deployed to your Kubernetes cluster, it should be reac
     "bitcoin_chain_tip": 116
 }
 ```
- - `GET/POST localhost:8477/api/v1/network/<network-id>/stacks-node/*` - Forwards `*` to the underlying stacks node pod of the devnet. If not all devnet assets exist for the given namespace, a 404 error will be returned.
+ - `GET/POST localhost:8477/api/v1/network/<network-id>/stacks-blockchain/*` - Forwards `*` to the underlying stacks node pod of the devnet. If not all devnet assets exist for the given namespace, a 404 error will be returned.
  - `GET/POST localhost:8477/api/v1/network/<network-id>/bitcoin-node/*` - Forwards `*` to the underlying bitcoin node pod of the devnet. If not all devnet assets exist for the given namespace, a 404 error will be returned.
-- `GET/POST localhost:8477/api/v1/network/<network-id>/stacks-api/*` - Forwards `*` to the underlying stacks api pod of the devnet. If not all devnet assets exist for the given namespace, a 404 error will be returned.
+- `GET/POST localhost:8477/api/v1/network/<network-id>/stacks-blockchain-api/*` - Forwards `*` to the underlying stacks api pod of the devnet. If not all devnet assets exist for the given namespace, a 404 error will be returned.
 
 ## Bugs and feature requests
 

--- a/scripts/deploy-api.sh
+++ b/scripts/deploy-api.sh
@@ -1,3 +1,3 @@
 kubectl --context kind-kind create namespace devnet
-kubectl --context kind-kind create configmap stacks-devnet-api-conf --from-file=./Config.toml --namespace devnet && \
+kubectl --context kind-kind create configmap stacks-devnet-api --from-file=./Config.toml --namespace devnet && \
 kubectl --context kind-kind apply -f ./templates/stacks-devnet-api.template.yaml

--- a/scripts/get-logs.sh
+++ b/scripts/get-logs.sh
@@ -1,5 +1,5 @@
-kubectl --context kind-kind logs stacks-node --namespace $1 > ./logs/stacks-node.txt & \
-kubectl --context kind-kind logs stacks-api --namespace $1 -c stacks-api-container > ./logs/stacks-api.txt & \
-kubectl --context kind-kind logs stacks-api --namespace $1 -c stacks-api-postgres > ./logs/stacks-api-postgres.txt & \
-kubectl --context kind-kind logs bitcoind-chain-coordinator --namespace $1 -c bitcoind-container > ./logs/bitcoin-node.txt & \
-kubectl --context kind-kind logs bitcoind-chain-coordinator --namespace $1 -c chain-coordinator-container > ./logs/chain-coordinator.txt 
+kubectl --context kind-kind logs stacks-blockchain --namespace $1 > ./logs/stacks-blockchain.txt & \
+kubectl --context kind-kind logs stacks-blockchain-api --namespace $1 -c stacks-blockchain-api > ./logs/stack-blockchains-api.txt & \
+kubectl --context kind-kind logs stacks-blockchain-api --namespace $1 -c postgres > ./logs/stacks-blockchain-api-pg.txt & \
+kubectl --context kind-kind logs bitcoind-chain-coordinator --namespace $1 -c bitcoind > ./logs/bitcoin-node.txt & \
+kubectl --context kind-kind logs bitcoind-chain-coordinator --namespace $1 -c chain-coordinator > ./logs/chain-coordinator.txt 

--- a/scripts/redeploy-api.sh
+++ b/scripts/redeploy-api.sh
@@ -1,3 +1,3 @@
-kubectl --context kind-kind delete configmap stacks-devnet-api-conf --namespace devnet & \
+kubectl --context kind-kind delete configmap stacks-devnet-api --namespace devnet & \
 kubectl --context kind-kind delete pod stacks-devnet-api --namespace devnet && \
 ./scripts/deploy-api.sh

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,27 +113,27 @@ impl StacksDevnetConfig {
                 .parse::<u16>()
                 .unwrap();
         devnet_config.stacks_node_p2p_port =
-            get_service_port(StacksDevnetService::StacksNode, ServicePort::P2P)
+            get_service_port(StacksDevnetService::StacksBlockchain, ServicePort::P2P)
                 .unwrap()
                 .parse::<u16>()
                 .unwrap();
         devnet_config.stacks_node_rpc_port =
-            get_service_port(StacksDevnetService::StacksNode, ServicePort::RPC)
+            get_service_port(StacksDevnetService::StacksBlockchain, ServicePort::RPC)
                 .unwrap()
                 .parse::<u16>()
                 .unwrap();
         devnet_config.stacks_api_port =
-            get_service_port(StacksDevnetService::StacksApi, ServicePort::API)
+            get_service_port(StacksDevnetService::StacksBlockchainApi, ServicePort::API)
                 .unwrap()
                 .parse::<u16>()
                 .unwrap();
         devnet_config.stacks_api_events_port =
-            get_service_port(StacksDevnetService::StacksApi, ServicePort::Event)
+            get_service_port(StacksDevnetService::StacksBlockchainApi, ServicePort::Event)
                 .unwrap()
                 .parse::<u16>()
                 .unwrap();
         devnet_config.postgres_port =
-            get_service_port(StacksDevnetService::StacksApi, ServicePort::DB)
+            get_service_port(StacksDevnetService::StacksBlockchainApi, ServicePort::DB)
                 .unwrap()
                 .parse::<u16>()
                 .unwrap();

--- a/src/resources/configmap.rs
+++ b/src/resources/configmap.rs
@@ -4,28 +4,26 @@ use strum_macros::EnumIter;
 #[derive(EnumIter, Debug)]
 pub enum StacksDevnetConfigmap {
     BitcoindNode,
-    StacksNode,
-    StacksApi,
-    StacksApiPostgres,
+    StacksBlockchain,
+    StacksBlockchainApi,
+    StacksBlockchainApiPg,
     DeploymentPlan,
     Devnet,
     ProjectDir,
-    Namespace,
     ProjectManifest,
 }
 
 impl fmt::Display for StacksDevnetConfigmap {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            StacksDevnetConfigmap::BitcoindNode => write!(f, "bitcoind-conf"),
-            StacksDevnetConfigmap::StacksNode => write!(f, "stacks-node-conf"),
-            StacksDevnetConfigmap::StacksApi => write!(f, "stacks-api-conf"),
-            StacksDevnetConfigmap::StacksApiPostgres => write!(f, "stacks-api-postgres-conf"),
-            StacksDevnetConfigmap::DeploymentPlan => write!(f, "deployment-plan-conf"),
-            StacksDevnetConfigmap::Devnet => write!(f, "devnet-conf"),
-            StacksDevnetConfigmap::ProjectDir => write!(f, "project-dir-conf"),
-            StacksDevnetConfigmap::Namespace => write!(f, "namespace-conf"),
-            StacksDevnetConfigmap::ProjectManifest => write!(f, "project-manifest-conf"),
+            StacksDevnetConfigmap::BitcoindNode => write!(f, "bitcoind"),
+            StacksDevnetConfigmap::StacksBlockchain => write!(f, "stacks-blockchain"),
+            StacksDevnetConfigmap::StacksBlockchainApi => write!(f, "stacks-blockchain-api"),
+            StacksDevnetConfigmap::StacksBlockchainApiPg => write!(f, "stacks-blockchain-api-pg"),
+            StacksDevnetConfigmap::DeploymentPlan => write!(f, "deployment-plan"),
+            StacksDevnetConfigmap::Devnet => write!(f, "devnet"),
+            StacksDevnetConfigmap::ProjectDir => write!(f, "project-dir"),
+            StacksDevnetConfigmap::ProjectManifest => write!(f, "project-manifest"),
         }
     }
 }

--- a/src/resources/pod.rs
+++ b/src/resources/pod.rs
@@ -4,16 +4,16 @@ use strum_macros::EnumIter;
 #[derive(EnumIter, Debug)]
 pub enum StacksDevnetPod {
     BitcoindNode,
-    StacksNode,
-    StacksApi,
+    StacksBlockchain,
+    StacksBlockchainApi,
 }
 
 impl fmt::Display for StacksDevnetPod {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             StacksDevnetPod::BitcoindNode => write!(f, "bitcoind-chain-coordinator"),
-            StacksDevnetPod::StacksNode => write!(f, "stacks-node"),
-            StacksDevnetPod::StacksApi => write!(f, "stacks-api"),
+            StacksDevnetPod::StacksBlockchain => write!(f, "stacks-blockchain"),
+            StacksDevnetPod::StacksBlockchainApi => write!(f, "stacks-blockchain-api"),
         }
     }
 }

--- a/src/resources/pvc.rs
+++ b/src/resources/pvc.rs
@@ -3,13 +3,13 @@ use strum_macros::EnumIter;
 
 #[derive(EnumIter, Debug)]
 pub enum StacksDevnetPvc {
-    StacksApi,
+    StacksBlockchainApiPg,
 }
 
 impl fmt::Display for StacksDevnetPvc {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            StacksDevnetPvc::StacksApi => write!(f, "stacks-api-pvc"),
+            StacksDevnetPvc::StacksBlockchainApiPg => write!(f, "stacks-blockchain-api-pg"),
         }
     }
 }

--- a/src/resources/service.rs
+++ b/src/resources/service.rs
@@ -4,8 +4,8 @@ use strum_macros::EnumIter;
 #[derive(EnumIter, Debug, Clone, PartialEq)]
 pub enum StacksDevnetService {
     BitcoindNode,
-    StacksNode,
-    StacksApi,
+    StacksBlockchain,
+    StacksBlockchainApi,
 }
 
 pub enum ServicePort {
@@ -21,9 +21,9 @@ pub enum ServicePort {
 impl fmt::Display for StacksDevnetService {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            StacksDevnetService::BitcoindNode => write!(f, "bitcoind-chain-coordinator-service"),
-            StacksDevnetService::StacksNode => write!(f, "stacks-node-service"),
-            StacksDevnetService::StacksApi => write!(f, "stacks-api-service"),
+            StacksDevnetService::BitcoindNode => write!(f, "bitcoind-chain-coordinator"),
+            StacksDevnetService::StacksBlockchain => write!(f, "stacks-blockchain"),
+            StacksDevnetService::StacksBlockchainApi => write!(f, "stacks-blockchain-api"),
         }
     }
 }
@@ -34,21 +34,21 @@ pub fn get_service_port(service: StacksDevnetService, port_type: ServicePort) ->
         (StacksDevnetService::BitcoindNode, ServicePort::P2P) => Some("18444".into()),
         (StacksDevnetService::BitcoindNode, ServicePort::Ingestion) => Some("20445".into()),
         (StacksDevnetService::BitcoindNode, ServicePort::Control) => Some("20446".into()),
-        (StacksDevnetService::StacksNode, ServicePort::RPC) => Some("20443".into()),
-        (StacksDevnetService::StacksNode, ServicePort::P2P) => Some("20444".into()),
-        (StacksDevnetService::StacksApi, ServicePort::API) => Some("3999".into()),
-        (StacksDevnetService::StacksApi, ServicePort::Event) => Some("3700".into()),
-        (StacksDevnetService::StacksApi, ServicePort::DB) => Some("5432".into()),
+        (StacksDevnetService::StacksBlockchain, ServicePort::RPC) => Some("20443".into()),
+        (StacksDevnetService::StacksBlockchain, ServicePort::P2P) => Some("20444".into()),
+        (StacksDevnetService::StacksBlockchainApi, ServicePort::API) => Some("3999".into()),
+        (StacksDevnetService::StacksBlockchainApi, ServicePort::Event) => Some("3700".into()),
+        (StacksDevnetService::StacksBlockchainApi, ServicePort::DB) => Some("5432".into()),
         (_, _) => None,
     }
 }
 
 pub fn get_user_facing_port(service: StacksDevnetService) -> Option<String> {
     match service {
-        StacksDevnetService::BitcoindNode | StacksDevnetService::StacksNode => {
+        StacksDevnetService::BitcoindNode | StacksDevnetService::StacksBlockchain => {
             get_service_port(service, ServicePort::RPC)
         }
-        StacksDevnetService::StacksApi => get_service_port(service, ServicePort::API),
+        StacksDevnetService::StacksBlockchainApi => get_service_port(service, ServicePort::API),
     }
 }
 
@@ -59,8 +59,8 @@ pub fn get_service_url(namespace: &str, service: StacksDevnetService) -> String 
 pub fn get_service_from_path_part(path_part: &str) -> Option<StacksDevnetService> {
     match path_part {
         "bitcoin-node" => Some(StacksDevnetService::BitcoindNode),
-        "stacks-node" => Some(StacksDevnetService::StacksNode),
-        "stacks-api" => Some(StacksDevnetService::StacksApi),
+        "stacks-blockchain" => Some(StacksDevnetService::StacksBlockchain),
+        "stacks-blockchain-api" => Some(StacksDevnetService::StacksBlockchainApi),
         _ => None,
     }
 }

--- a/src/resources/tests.rs
+++ b/src/resources/tests.rs
@@ -5,34 +5,33 @@ use super::{
 };
 use test_case::test_case;
 
-#[test_case(StacksDevnetConfigmap::BitcoindNode => is equal_to  "bitcoind-conf".to_string(); "for BitcoinNode")]
-#[test_case(StacksDevnetConfigmap::StacksNode => is equal_to  "stacks-node-conf".to_string(); "for StacksNode")]
-#[test_case(StacksDevnetConfigmap::StacksApi => is equal_to  "stacks-api-conf".to_string(); "for StacksApi")]
-#[test_case(StacksDevnetConfigmap::StacksApiPostgres => is equal_to  "stacks-api-postgres-conf".to_string(); "for StacksApiPostgres")]
-#[test_case(StacksDevnetConfigmap::DeploymentPlan => is equal_to  "deployment-plan-conf".to_string(); "for DeploymentPlan")]
-#[test_case(StacksDevnetConfigmap::Devnet => is equal_to  "devnet-conf".to_string(); "for Devnet")]
-#[test_case(StacksDevnetConfigmap::ProjectDir => is equal_to  "project-dir-conf".to_string(); "for ProjectDir")]
-#[test_case(StacksDevnetConfigmap::Namespace => is equal_to  "namespace-conf".to_string(); "for Namespace")]
-#[test_case(StacksDevnetConfigmap::ProjectManifest => is equal_to  "project-manifest-conf".to_string(); "for ProjectManifest")]
+#[test_case(StacksDevnetConfigmap::BitcoindNode => is equal_to  "bitcoind".to_string(); "for BitcoinNode")]
+#[test_case(StacksDevnetConfigmap::StacksBlockchain => is equal_to  "stacks-blockchain".to_string(); "for StacksNode")]
+#[test_case(StacksDevnetConfigmap::StacksBlockchainApi => is equal_to  "stacks-blockchain-api".to_string(); "for StacksBlockchainApi")]
+#[test_case(StacksDevnetConfigmap::StacksBlockchainApiPg => is equal_to  "stacks-blockchain-api-pg".to_string(); "for StacksBlockchainApiPg")]
+#[test_case(StacksDevnetConfigmap::DeploymentPlan => is equal_to  "deployment-plan".to_string(); "for DeploymentPlan")]
+#[test_case(StacksDevnetConfigmap::Devnet => is equal_to  "devnet".to_string(); "for Devnet")]
+#[test_case(StacksDevnetConfigmap::ProjectDir => is equal_to  "project-dir".to_string(); "for ProjectDir")]
+#[test_case(StacksDevnetConfigmap::ProjectManifest => is equal_to  "project-manifest".to_string(); "for ProjectManifest")]
 fn it_prints_correct_name_for_configmap(configmap: StacksDevnetConfigmap) -> String {
     configmap.to_string()
 }
 
 #[test_case(StacksDevnetPod::BitcoindNode => is equal_to  "bitcoind-chain-coordinator".to_string(); "for BitcoindNode")]
-#[test_case(StacksDevnetPod::StacksNode => is equal_to  "stacks-node".to_string(); "for StacksNode")]
-#[test_case(StacksDevnetPod::StacksApi => is equal_to  "stacks-api".to_string(); "for StacksApi")]
+#[test_case(StacksDevnetPod::StacksBlockchain => is equal_to  "stacks-blockchain".to_string(); "for StacksNode")]
+#[test_case(StacksDevnetPod::StacksBlockchainApi => is equal_to  "stacks-blockchain-api".to_string(); "for StacksBlockchainApi")]
 fn it_prints_correct_name_for_pod(pod: StacksDevnetPod) -> String {
     pod.to_string()
 }
 
-#[test_case(StacksDevnetPvc::StacksApi => is equal_to  "stacks-api-pvc".to_string(); "for StacksApi")]
+#[test_case(StacksDevnetPvc::StacksBlockchainApiPg => is equal_to  "stacks-blockchain-api-pg".to_string(); "for StacksBlockchainApiPg")]
 fn it_prints_correct_name_for_pvc(pvc: StacksDevnetPvc) -> String {
     pvc.to_string()
 }
 
-#[test_case(StacksDevnetService::BitcoindNode => is equal_to  "bitcoind-chain-coordinator-service".to_string(); "for BitcoindNode")]
-#[test_case(StacksDevnetService::StacksNode => is equal_to  "stacks-node-service".to_string(); "for StacksNode")]
-#[test_case(StacksDevnetService::StacksApi => is equal_to  "stacks-api-service".to_string(); "for StacksApi")]
+#[test_case(StacksDevnetService::BitcoindNode => is equal_to  "bitcoind-chain-coordinator".to_string(); "for BitcoindNode")]
+#[test_case(StacksDevnetService::StacksBlockchain => is equal_to  "stacks-blockchain".to_string(); "for StacksNode")]
+#[test_case(StacksDevnetService::StacksBlockchainApi => is equal_to  "stacks-blockchain-api".to_string(); "for StacksBlockchainApi")]
 fn it_prints_correct_name_for_service(service: StacksDevnetService) -> String {
     service.to_string()
 }
@@ -41,12 +40,12 @@ fn it_prints_correct_name_for_service(service: StacksDevnetService) -> String {
 #[test_case(StacksDevnetService::BitcoindNode, ServicePort::P2P => is equal_to  Some("18444".to_string()); "for BitcoindNode P2P port")]
 #[test_case(StacksDevnetService::BitcoindNode, ServicePort::Ingestion => is equal_to  Some("20445".to_string()); "for BitcoindNode Ingestion port")]
 #[test_case(StacksDevnetService::BitcoindNode, ServicePort::Control => is equal_to  Some("20446".to_string()); "for BitcoindNode Control port")]
-#[test_case(StacksDevnetService::StacksNode, ServicePort::RPC => is equal_to  Some("20443".to_string()); "for StacksNode RPC port")]
-#[test_case(StacksDevnetService::StacksNode, ServicePort::P2P => is equal_to  Some("20444".to_string()); "for StacksNode P2P port")]
-#[test_case(StacksDevnetService::StacksApi, ServicePort::API => is equal_to  Some("3999".to_string()); "for StacksApi API port")]
-#[test_case(StacksDevnetService::StacksApi, ServicePort::Event => is equal_to  Some("3700".to_string()); "for StacksApi Event port")]
-#[test_case(StacksDevnetService::StacksApi, ServicePort::DB => is equal_to  Some("5432".to_string()); "for StacksApi DB port")]
-#[test_case(StacksDevnetService::StacksApi, ServicePort::RPC => is equal_to  None; "invalid service port combination")]
+#[test_case(StacksDevnetService::StacksBlockchain, ServicePort::RPC => is equal_to  Some("20443".to_string()); "for StacksNode RPC port")]
+#[test_case(StacksDevnetService::StacksBlockchain, ServicePort::P2P => is equal_to  Some("20444".to_string()); "for StacksNode P2P port")]
+#[test_case(StacksDevnetService::StacksBlockchainApi, ServicePort::API => is equal_to  Some("3999".to_string()); "for StacksBlockchainApi API port")]
+#[test_case(StacksDevnetService::StacksBlockchainApi, ServicePort::Event => is equal_to  Some("3700".to_string()); "for StacksBlockchainApi Event port")]
+#[test_case(StacksDevnetService::StacksBlockchainApi, ServicePort::DB => is equal_to  Some("5432".to_string()); "for StacksBlockchainApi DB port")]
+#[test_case(StacksDevnetService::StacksBlockchainApi, ServicePort::RPC => is equal_to  None; "invalid service port combination")]
 fn it_gets_correct_port_for_service(
     service: StacksDevnetService,
     port_type: ServicePort,
@@ -55,16 +54,16 @@ fn it_gets_correct_port_for_service(
 }
 
 #[test_case("bitcoin-node" => is equal_to Some(StacksDevnetService::BitcoindNode); "for bitcoin-node")]
-#[test_case("stacks-node" => is equal_to Some(StacksDevnetService::StacksNode); "for stacks-node")]
-#[test_case("stacks-api" => is equal_to Some(StacksDevnetService::StacksApi); "for stacks-api")]
+#[test_case("stacks-blockchain" => is equal_to Some(StacksDevnetService::StacksBlockchain); "for stacks-blockchain")]
+#[test_case("stacks-blockchain-api" => is equal_to Some(StacksDevnetService::StacksBlockchainApi); "for stacks-blockchain-api")]
 #[test_case("invalid" => is equal_to None; "returning None for invalid paths")]
 fn it_prints_service_from_path_part(path_part: &str) -> Option<StacksDevnetService> {
     get_service_from_path_part(path_part)
 }
 
 #[test_case(StacksDevnetService::BitcoindNode => is equal_to  Some("18443".to_string()); "for BitcoindNode")]
-#[test_case(StacksDevnetService::StacksNode => is equal_to  Some("20443".to_string()); "for StacksNode")]
-#[test_case(StacksDevnetService::StacksApi => is equal_to  Some("3999".to_string()); "for StacksApi")]
+#[test_case(StacksDevnetService::StacksBlockchain => is equal_to  Some("20443".to_string()); "for StacksBlockchain")]
+#[test_case(StacksDevnetService::StacksBlockchainApi => is equal_to  Some("3999".to_string()); "for StacksBlockchainApi")]
 fn it_gets_user_facing_port_for_service(service: StacksDevnetService) -> Option<String> {
     get_user_facing_port(service)
 }

--- a/src/resources/tests.rs
+++ b/src/resources/tests.rs
@@ -6,7 +6,7 @@ use super::{
 use test_case::test_case;
 
 #[test_case(StacksDevnetConfigmap::BitcoindNode => is equal_to  "bitcoind".to_string(); "for BitcoinNode")]
-#[test_case(StacksDevnetConfigmap::StacksBlockchain => is equal_to  "stacks-blockchain".to_string(); "for StacksNode")]
+#[test_case(StacksDevnetConfigmap::StacksBlockchain => is equal_to  "stacks-blockchain".to_string(); "for StacksBlockchain")]
 #[test_case(StacksDevnetConfigmap::StacksBlockchainApi => is equal_to  "stacks-blockchain-api".to_string(); "for StacksBlockchainApi")]
 #[test_case(StacksDevnetConfigmap::StacksBlockchainApiPg => is equal_to  "stacks-blockchain-api-pg".to_string(); "for StacksBlockchainApiPg")]
 #[test_case(StacksDevnetConfigmap::DeploymentPlan => is equal_to  "deployment-plan".to_string(); "for DeploymentPlan")]
@@ -18,7 +18,7 @@ fn it_prints_correct_name_for_configmap(configmap: StacksDevnetConfigmap) -> Str
 }
 
 #[test_case(StacksDevnetPod::BitcoindNode => is equal_to  "bitcoind-chain-coordinator".to_string(); "for BitcoindNode")]
-#[test_case(StacksDevnetPod::StacksBlockchain => is equal_to  "stacks-blockchain".to_string(); "for StacksNode")]
+#[test_case(StacksDevnetPod::StacksBlockchain => is equal_to  "stacks-blockchain".to_string(); "for StacksBlockchain")]
 #[test_case(StacksDevnetPod::StacksBlockchainApi => is equal_to  "stacks-blockchain-api".to_string(); "for StacksBlockchainApi")]
 fn it_prints_correct_name_for_pod(pod: StacksDevnetPod) -> String {
     pod.to_string()
@@ -30,7 +30,7 @@ fn it_prints_correct_name_for_pvc(pvc: StacksDevnetPvc) -> String {
 }
 
 #[test_case(StacksDevnetService::BitcoindNode => is equal_to  "bitcoind-chain-coordinator".to_string(); "for BitcoindNode")]
-#[test_case(StacksDevnetService::StacksBlockchain => is equal_to  "stacks-blockchain".to_string(); "for StacksNode")]
+#[test_case(StacksDevnetService::StacksBlockchain => is equal_to  "stacks-blockchain".to_string(); "for StacksBlockchain")]
 #[test_case(StacksDevnetService::StacksBlockchainApi => is equal_to  "stacks-blockchain-api".to_string(); "for StacksBlockchainApi")]
 fn it_prints_correct_name_for_service(service: StacksDevnetService) -> String {
     service.to_string()
@@ -40,8 +40,8 @@ fn it_prints_correct_name_for_service(service: StacksDevnetService) -> String {
 #[test_case(StacksDevnetService::BitcoindNode, ServicePort::P2P => is equal_to  Some("18444".to_string()); "for BitcoindNode P2P port")]
 #[test_case(StacksDevnetService::BitcoindNode, ServicePort::Ingestion => is equal_to  Some("20445".to_string()); "for BitcoindNode Ingestion port")]
 #[test_case(StacksDevnetService::BitcoindNode, ServicePort::Control => is equal_to  Some("20446".to_string()); "for BitcoindNode Control port")]
-#[test_case(StacksDevnetService::StacksBlockchain, ServicePort::RPC => is equal_to  Some("20443".to_string()); "for StacksNode RPC port")]
-#[test_case(StacksDevnetService::StacksBlockchain, ServicePort::P2P => is equal_to  Some("20444".to_string()); "for StacksNode P2P port")]
+#[test_case(StacksDevnetService::StacksBlockchain, ServicePort::RPC => is equal_to  Some("20443".to_string()); "for StacksBlockchain RPC port")]
+#[test_case(StacksDevnetService::StacksBlockchain, ServicePort::P2P => is equal_to  Some("20444".to_string()); "for StacksBlockchain P2P port")]
 #[test_case(StacksDevnetService::StacksBlockchainApi, ServicePort::API => is equal_to  Some("3999".to_string()); "for StacksBlockchainApi API port")]
 #[test_case(StacksDevnetService::StacksBlockchainApi, ServicePort::Event => is equal_to  Some("3700".to_string()); "for StacksBlockchainApi Event port")]
 #[test_case(StacksDevnetService::StacksBlockchainApi, ServicePort::DB => is equal_to  Some("5432".to_string()); "for StacksBlockchainApi DB port")]

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -6,52 +6,49 @@ use crate::resources::{
 pub fn get_yaml_from_resource(resource: StacksDevnetResource) -> &'static str {
     match resource {
         StacksDevnetResource::Pod(StacksDevnetPod::BitcoindNode) => {
-            include_str!("../templates/bitcoind-chain-coordinator-pod.template.yaml")
+            include_str!("../templates/pods/bitcoind-chain-coordinator.template.yaml")
         }
         StacksDevnetResource::Service(StacksDevnetService::BitcoindNode) => {
-            include_str!("../templates/bitcoind-chain-coordinator-service.template.yaml")
+            include_str!("../templates/services/bitcoind-chain-coordinator.template.yaml")
         }
         StacksDevnetResource::Configmap(StacksDevnetConfigmap::BitcoindNode) => {
-            include_str!("../templates/bitcoind-configmap.template.yaml")
+            include_str!("../templates/configmaps/bitcoind.template.yaml")
         }
         StacksDevnetResource::Configmap(StacksDevnetConfigmap::DeploymentPlan) => {
-            include_str!("../templates/chain-coord-deployment-plan-configmap.template.yaml")
+            include_str!("../templates/configmaps/chain-coord-deployment-plan.template.yaml")
         }
         StacksDevnetResource::Configmap(StacksDevnetConfigmap::Devnet) => {
-            include_str!("../templates/chain-coord-devnet-configmap.template.yaml")
-        }
-        StacksDevnetResource::Configmap(StacksDevnetConfigmap::Namespace) => {
-            include_str!("../templates/chain-coord-namespace-configmap.template.yaml")
+            include_str!("../templates/configmaps/chain-coord-devnet.template.yaml")
         }
         StacksDevnetResource::Configmap(StacksDevnetConfigmap::ProjectDir) => {
-            include_str!("../templates/chain-coord-project-dir-configmap.template.yaml")
+            include_str!("../templates/configmaps/chain-coord-project-dir.template.yaml")
         }
         StacksDevnetResource::Configmap(StacksDevnetConfigmap::ProjectManifest) => {
-            include_str!("../templates/chain-coord-project-manifest-configmap.template.yaml")
+            include_str!("../templates/configmaps/chain-coord-project-manifest.template.yaml")
         }
-        StacksDevnetResource::Configmap(StacksDevnetConfigmap::StacksApi) => {
-            include_str!("../templates/stacks-api-configmap.template.yaml")
+        StacksDevnetResource::Configmap(StacksDevnetConfigmap::StacksBlockchainApi) => {
+            include_str!("../templates/configmaps/stacks-blockchain-api.template.yaml")
         }
-        StacksDevnetResource::Pod(StacksDevnetPod::StacksApi) => {
-            include_str!("../templates/stacks-api-pod.template.yaml")
+        StacksDevnetResource::Pod(StacksDevnetPod::StacksBlockchainApi) => {
+            include_str!("../templates/pods/stacks-blockchain-api.template.yaml")
         }
-        StacksDevnetResource::Configmap(StacksDevnetConfigmap::StacksApiPostgres) => {
-            include_str!("../templates/stacks-api-postgres-configmap.template.yaml")
+        StacksDevnetResource::Configmap(StacksDevnetConfigmap::StacksBlockchainApiPg) => {
+            include_str!("../templates/configmaps/stacks-blockchain-api-pg.template.yaml")
         }
-        StacksDevnetResource::Pvc(StacksDevnetPvc::StacksApi) => {
-            include_str!("../templates/stacks-api-pvc.template.yaml")
+        StacksDevnetResource::Pvc(StacksDevnetPvc::StacksBlockchainApiPg) => {
+            include_str!("../templates/pvcs/stacks-blockchain-api-pg.template.yaml")
         }
-        StacksDevnetResource::Service(StacksDevnetService::StacksApi) => {
-            include_str!("../templates/stacks-api-service.template.yaml")
+        StacksDevnetResource::Service(StacksDevnetService::StacksBlockchainApi) => {
+            include_str!("../templates/services/stacks-blockchain-api.template.yaml")
         }
-        StacksDevnetResource::Configmap(StacksDevnetConfigmap::StacksNode) => {
-            include_str!("../templates/stacks-node-configmap.template.yaml")
+        StacksDevnetResource::Configmap(StacksDevnetConfigmap::StacksBlockchain) => {
+            include_str!("../templates/configmaps/stacks-blockchain.template.yaml")
         }
-        StacksDevnetResource::Pod(StacksDevnetPod::StacksNode) => {
-            include_str!("../templates/stacks-node-pod.template.yaml")
+        StacksDevnetResource::Pod(StacksDevnetPod::StacksBlockchain) => {
+            include_str!("../templates/pods/stacks-blockchain.template.yaml")
         }
-        StacksDevnetResource::Service(StacksDevnetService::StacksNode) => {
-            include_str!("../templates/stacks-node-service.template.yaml")
+        StacksDevnetResource::Service(StacksDevnetService::StacksBlockchain) => {
+            include_str!("../templates/services/stacks-blockchain.template.yaml")
         }
         StacksDevnetResource::Namespace => include_str!("../templates/namespace.template.yaml"),
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -112,7 +112,7 @@ enum TestBody {
 #[test_case("/api/v1/networks", Method::POST, Some(TestBody::CreateNetwork), true => using assert_cannot_create_devnet_err; "409 for create network POST request if devnet exists")]
 #[test_case("/api/v1/network/{namespace}", Method::GET, None, true => using assert_get_network; "200 for network GET request to existing network")]
 #[test_case("/api/v1/network/{namespace}", Method::HEAD, None, true => is equal_to (StatusCode::OK, "Ok".to_string()); "200 for network HEAD request to existing network")]
-#[test_case("/api/v1/network/{namespace}/stacks-node/v2/info/", Method::GET, None, true => using assert_failed_proxy; "proxies requests to downstream nodes")]
+#[test_case("/api/v1/network/{namespace}/stacks-blockchain/v2/info/", Method::GET, None, true => using assert_failed_proxy; "proxies requests to downstream nodes")]
 #[serial_test::serial]
 #[tokio::test]
 async fn it_responds_to_valid_requests_with_deploy(
@@ -178,7 +178,7 @@ async fn it_responds_to_valid_requests_with_deploy(
 #[test_case("/api/v1/network/{namespace}", Method::DELETE, true => using assert_cannot_delete_devnet_err; "409 for network DELETE request to non-existing network")]
 #[test_case("/api/v1/network/{namespace}", Method::GET, true => using assert_not_all_assets_exist_err; "404 for network GET request to non-existing network")]
 #[test_case("/api/v1/network/{namespace}", Method::HEAD, true => is equal_to (StatusCode::NOT_FOUND, "not found".to_string()); "404 for network HEAD request to non-existing network")]
-#[test_case("/api/v1/network/{namespace}/stacks-node/v2/info/", Method::GET, true => using assert_not_all_assets_exist_err; "404 for proxy requests to downstream nodes of non-existing network")]
+#[test_case("/api/v1/network/{namespace}/stacks-blockchain/v2/info/", Method::GET, true => using assert_not_all_assets_exist_err; "404 for proxy requests to downstream nodes of non-existing network")]
 #[tokio::test]
 async fn it_responds_to_valid_requests(
     mut request_path: &str,
@@ -364,7 +364,7 @@ fn request_paths_are_parsed_correctly(path: &str) -> PathParts {
 
 #[tokio::test]
 async fn request_mutation_should_create_valid_proxy_destination() {
-    let path = "/api/v1/some-route/some-network/stacks-node/the//remaining///path";
+    let path = "/api/v1/some-route/some-network/stacks-blockchain/the//remaining///path";
     let path_parts = get_standardized_path_parts(path);
     let network = path_parts.network.unwrap();
     let subroute = path_parts.subroute.unwrap();
@@ -382,9 +382,9 @@ async fn request_mutation_should_create_valid_proxy_destination() {
     let actual_url = request.uri().to_string();
     let expected = format!(
         "http://{}.{}.svc.cluster.local:{}/{}",
-        StacksDevnetService::StacksNode,
+        StacksDevnetService::StacksBlockchain,
         network,
-        get_service_port(StacksDevnetService::StacksNode, ServicePort::RPC).unwrap(),
+        get_service_port(StacksDevnetService::StacksBlockchain, ServicePort::RPC).unwrap(),
         &remainder
     );
     assert_eq!(actual_url, expected);

--- a/templates/bitcoind-configmap.template.yaml
+++ b/templates/bitcoind-configmap.template.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-data:
-  bitcoin.conf: "{data}"
-kind: ConfigMap
-metadata:
-  name: bitcoind-conf
-  namespace: "{namespace}"

--- a/templates/ci/stacks-devnet-api.template.yaml
+++ b/templates/ci/stacks-devnet-api.template.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: stacks-devnet-api-service-account
+  name: stacks-devnet-api
   namespace: devnet
 
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stacks-devnet-api-service-account
+  name: stacks-devnet-api
 rules:
   - apiGroups: [""]
     resources: ["pods", "pods/status", "services", "configmaps", "persistentvolumeclaims"]
@@ -21,14 +21,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: stacks-devnet-api-service-account
+  name: stacks-devnet-api
 subjects:
   - kind: ServiceAccount
-    name: stacks-devnet-api-service-account
+    name: stacks-devnet-api
     namespace: devnet
 roleRef:
   kind: ClusterRole
-  name: stacks-devnet-api-service-account
+  name: stacks-devnet-api
   apiGroup: rbac.authorization.k8s.io
 
 ---  
@@ -41,10 +41,10 @@ metadata:
   name: stacks-devnet-api
   namespace: devnet
 spec:
-  serviceAccountName: stacks-devnet-api-service-account
+  serviceAccountName: stacks-devnet-api
   containers:
   - command: ["stacks-devnet-api"]
-    name: stacks-devnet-api-container
+    name: stacks-devnet-api
     image: hirosystems/stacks-devnet-api:ci
     imagePullPolicy: Never
     ports:
@@ -57,13 +57,13 @@ spec:
   volumes:
     - name: config-volume
       configMap:
-        name: stacks-devnet-api-conf
+        name: stacks-devnet-api
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: stacks-devnet-api-service
+  name: stacks-devnet-api
   namespace: devnet
 spec:
   ports:

--- a/templates/configmaps/bitcoind.template.yaml
+++ b/templates/configmaps/bitcoind.template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-  key: "{value}"
+  bitcoin.conf: "{data}"
 kind: ConfigMap
 metadata:
-  name: stacks-api-conf
+  name: bitcoind
   namespace: "{namespace}"

--- a/templates/configmaps/chain-coord-deployment-plan.template.yaml
+++ b/templates/configmaps/chain-coord-deployment-plan.template.yaml
@@ -3,5 +3,5 @@ data:
   key: "{value}"
 kind: ConfigMap
 metadata:
-  name: project-dir-conf
+  name: deployment-plan
   namespace: "{namespace}"

--- a/templates/configmaps/chain-coord-devnet.template.yaml
+++ b/templates/configmaps/chain-coord-devnet.template.yaml
@@ -3,5 +3,5 @@ data:
   key: "{value}"
 kind: ConfigMap
 metadata:
-  name: namespace-conf
+  name: devnet
   namespace: "{namespace}"

--- a/templates/configmaps/chain-coord-project-dir.template.yaml
+++ b/templates/configmaps/chain-coord-project-dir.template.yaml
@@ -3,5 +3,5 @@ data:
   key: "{value}"
 kind: ConfigMap
 metadata:
-  name: deployment-plan-conf
+  name: project-dir
   namespace: "{namespace}"

--- a/templates/configmaps/chain-coord-project-manifest.template.yaml
+++ b/templates/configmaps/chain-coord-project-manifest.template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-  Stacks.toml: "{data}"
+  key: "{value}"
 kind: ConfigMap
 metadata:
-  name: stacks-node-conf
+  name: project-manifest
   namespace: "{namespace}"

--- a/templates/configmaps/stacks-blockchain-api-pg.template.yaml
+++ b/templates/configmaps/stacks-blockchain-api-pg.template.yaml
@@ -3,5 +3,5 @@ data:
   key: "{value}"
 kind: ConfigMap
 metadata:
-  name: project-manifest-conf
+  name: stacks-blockchain-api-pg
   namespace: "{namespace}"

--- a/templates/configmaps/stacks-blockchain-api.template.yaml
+++ b/templates/configmaps/stacks-blockchain-api.template.yaml
@@ -3,5 +3,5 @@ data:
   key: "{value}"
 kind: ConfigMap
 metadata:
-  name: devnet-conf
+  name: stacks-blockchain-api
   namespace: "{namespace}"

--- a/templates/configmaps/stacks-blockchain.template.yaml
+++ b/templates/configmaps/stacks-blockchain.template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-  key: "{value}"
+  Stacks.toml: "{data}"
 kind: ConfigMap
 metadata:
-  name: stacks-api-postgres-conf
+  name: stacks-blockchain
   namespace: "{namespace}"

--- a/templates/pods/bitcoind-chain-coordinator.template.yaml
+++ b/templates/pods/bitcoind-chain-coordinator.template.yaml
@@ -14,7 +14,7 @@ spec:
     - -pid=/run/bitcoind.pid
     image: quay.io/hirosystems/bitcoind:devnet-v3
     imagePullPolicy: IfNotPresent
-    name: bitcoind-container
+    name: bitcoind
     ports:
     - containerPort: 18444
       name: p2p
@@ -24,7 +24,7 @@ spec:
       protocol: TCP
     volumeMounts:
     - mountPath: /etc/bitcoin
-      name: bitcoind-conf-volume
+      name: bitcoind
       readOnly: true
   - command:
     - ./stacks-network
@@ -36,12 +36,12 @@ spec:
     env:
       - name: NAMESPACE
         valueFrom:
-          configMapKeyRef:
-            name: namespace-conf
-            key: NAMESPACE
+          fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.namespace
     image: hirosystems/stacks-network-orchestrator:latest
     imagePullPolicy: Always
-    name: chain-coordinator-container
+    name: chain-coordinator
     ports:
     - containerPort: 20445
       name: coordinator-in
@@ -51,26 +51,26 @@ spec:
       protocol: TCP
     volumeMounts:
     - mountPath: /etc/stacks-network/project
-      name: project-manifest-conf-volume
+      name: project-manifest
     - mountPath: /etc/stacks-network/project/settings
-      name: devnet-conf-volume
+      name: devnet
     - mountPath: /etc/stacks-network/project/deployments
-      name: deployment-plan-conf-volume
+      name: deployment-plan
     - mountPath: /etc/stacks-network/project/contracts
-      name: project-dir-conf-volume
+      name: project-dir
   volumes:
   - configMap:
-      name: bitcoind-conf
-    name: bitcoind-conf-volume
+      name: bitcoind
+    name: bitcoind
   - configMap:
-      name: project-manifest-conf
-    name: project-manifest-conf-volume
+      name: project-manifest
+    name: project-manifest
   - configMap:
-      name: devnet-conf
-    name: devnet-conf-volume
+      name: devnet
+    name: devnet
   - configMap:
-      name: deployment-plan-conf
-    name: deployment-plan-conf-volume
+      name: deployment-plan
+    name: deployment-plan
   - configMap:
-      name: project-dir-conf
-    name: project-dir-conf-volume
+      name: project-dir
+    name: project-dir

--- a/templates/pods/stacks-blockchain-api.template.yaml
+++ b/templates/pods/stacks-blockchain-api.template.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "{namespace}"
 spec:
   containers:
-  - name: stack-blockchain-api
+  - name: stacks-blockchain-api
     envFrom:
       - configMapRef:
           name: stacks-blockchain-api

--- a/templates/pods/stacks-blockchain-api.template.yaml
+++ b/templates/pods/stacks-blockchain-api.template.yaml
@@ -2,15 +2,15 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    name: stacks-api
-  name: stacks-api
+    name: stacks-blockchain-api
+  name: stacks-blockchain-api
   namespace: "{namespace}"
 spec:
   containers:
-  - name: stacks-api-container
+  - name: stack-blockchains-api
     envFrom:
       - configMapRef:
-          name: stacks-api-conf
+          name: stacks-blockchain-api
           optional: false
     image: hirosystems/stacks-blockchain-api
     imagePullPolicy: Never
@@ -21,10 +21,10 @@ spec:
     - containerPort: 3700
       name: eventport
       protocol: TCP
-  - name: stacks-api-postgres
+  - name: postgres
     envFrom:
       - configMapRef:
-          name: stacks-api-postgres-conf
+          name: stacks-blockchain-api-pg
           optional: false
     image: postgres:14
     imagePullPolicy: IfNotPresent
@@ -34,8 +34,8 @@ spec:
       protocol: TCP
     volumeMounts:
     - mountPath: /var/lib/postgresql/data
-      name: stacks-api-conf-volume
+      name: stacks-blockchain-api
   volumes:
-  - name: stacks-api-conf-volume
+  - name: stacks-blockchain-api
     persistentVolumeClaim:
-      claimName: stacks-api-pvc
+      claimName: stacks-blockchain-api

--- a/templates/pods/stacks-blockchain-api.template.yaml
+++ b/templates/pods/stacks-blockchain-api.template.yaml
@@ -34,8 +34,8 @@ spec:
       protocol: TCP
     volumeMounts:
     - mountPath: /var/lib/postgresql/data
-      name: stacks-blockchain-api
+      name: stacks-blockchain-api-pg
   volumes:
-  - name: stacks-blockchain-api
+  - name: stacks-blockchain-api-pg
     persistentVolumeClaim:
-      claimName: stacks-blockchain-api
+      claimName: stacks-blockchain-api-pg

--- a/templates/pods/stacks-blockchain-api.template.yaml
+++ b/templates/pods/stacks-blockchain-api.template.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "{namespace}"
 spec:
   containers:
-  - name: stack-blockchains-api
+  - name: stack-blockchain-api
     envFrom:
       - configMapRef:
           name: stacks-blockchain-api

--- a/templates/pods/stacks-blockchain.template.yaml
+++ b/templates/pods/stacks-blockchain.template.yaml
@@ -2,15 +2,15 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    name: stacks-node
-  name: stacks-node
+    name: stacks-blockchain
+  name: stacks-blockchain
   namespace: "{namespace}"
 spec:
   containers:
   - command:
-    - stacks-node
+    - stacks-blockchain
     - start
-    - --config=/src/stacks-node/Stacks.toml
+    - --config=/src/stacks-blockchain/Stacks.toml
     env:
     - name: STACKS_LOG_PP
       value: "1"
@@ -18,9 +18,9 @@ spec:
       value: "1"
     - name: STACKS_LOG_DEBUG
       value: "0"
-    image: quay.io/hirosystems/stacks-node:devnet-v3
+    image: quay.io/hirosystems/stacks-blockchain:devnet-v3
     imagePullPolicy: IfNotPresent
-    name: stacks-node-container
+    name: stacks-blockchain
     ports:
     - containerPort: 20444
       name: p2p
@@ -29,10 +29,10 @@ spec:
       name: rpc
       protocol: TCP
     volumeMounts:
-    - mountPath: /src/stacks-node
-      name: stacks-node-conf-volume
+    - mountPath: /src/stacks-blockchain
+      name: stacks-blockchain
       readOnly: true
   volumes:
   - configMap:
-      name: stacks-node-conf
-    name: stacks-node-conf-volume
+      name: stacks-blockchain
+    name: stacks-blockchain

--- a/templates/pods/stacks-blockchain.template.yaml
+++ b/templates/pods/stacks-blockchain.template.yaml
@@ -18,7 +18,7 @@ spec:
       value: "1"
     - name: STACKS_LOG_DEBUG
       value: "0"
-    image: quay.io/hirosystems/stacks-blockchain:devnet-v3
+    image: quay.io/hirosystems/stacks-node:devnet-v3
     imagePullPolicy: IfNotPresent
     name: stacks-blockchain
     ports:

--- a/templates/pods/stacks-blockchain.template.yaml
+++ b/templates/pods/stacks-blockchain.template.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - command:
-    - stacks-blockchain
+    - stacks-node
     - start
     - --config=/src/stacks-blockchain/Stacks.toml
     env:

--- a/templates/pvcs/stacks-blockchain-api-pg.template.yaml
+++ b/templates/pvcs/stacks-blockchain-api-pg.template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: stacks-api-pvc
+  name: stacks-blockchain-api-pg
   namespace: "{namespace}"
 spec:
   accessModes:

--- a/templates/services/bitcoind-chain-coordinator.template.yaml
+++ b/templates/services/bitcoind-chain-coordinator.template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: bitcoind-chain-coordinator-service
+  name: bitcoind-chain-coordinator
   namespace: "{namespace}"
 spec:
   ports:

--- a/templates/services/stacks-blockchain-api.template.yaml
+++ b/templates/services/stacks-blockchain-api.template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: stacks-api-service
+  name: stacks-blockchain-api
   namespace: "{namespace}"
 spec:
   ports:
@@ -18,4 +18,4 @@ spec:
     protocol: TCP
     targetPort: 3700
   selector:
-    name: stacks-api
+    name: stacks-blockchain-api

--- a/templates/services/stacks-blockchain.template.yaml
+++ b/templates/services/stacks-blockchain.template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: stacks-node-service
+  name: stacks-blockchain
   namespace: "{namespace}"
 spec:
   ports:
@@ -12,4 +12,4 @@ spec:
     port: 20443
     protocol: TCP
   selector:
-    name: stacks-node
+    name: stacks-blockchain

--- a/templates/stacks-devnet-api.template.yaml
+++ b/templates/stacks-devnet-api.template.yaml
@@ -22,7 +22,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: stacks-devnet-apit
+  name: stacks-devnet-api
 subjects:
   - kind: ServiceAccount
     name: stacks-devnet-api

--- a/templates/stacks-devnet-api.template.yaml
+++ b/templates/stacks-devnet-api.template.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: stacks-devnet-api-service-account
+  name: stacks-devnet-api
   namespace: devnet
 
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: stacks-devnet-api-service-account
+  name: stacks-devnet-api
 rules:
   - apiGroups: [""]
     resources: ["pods", "pods/status", "services", "configmaps", "persistentvolumeclaims"]
@@ -22,14 +22,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: stacks-devnet-api-service-account
+  name: stacks-devnet-apit
 subjects:
   - kind: ServiceAccount
-    name: stacks-devnet-api-service-account
+    name: stacks-devnet-api
     namespace: devnet
 roleRef:
   kind: ClusterRole
-  name: stacks-devnet-api-service-account
+  name: stacks-devnet-api
   apiGroup: rbac.authorization.k8s.io
 
 ---  
@@ -42,10 +42,10 @@ metadata:
   name: stacks-devnet-api
   namespace: devnet
 spec:
-  serviceAccountName: stacks-devnet-api-service-account
+  serviceAccountName: stacks-devnet-api
   containers:
   - command: ["stacks-devnet-api"]
-    name: stacks-devnet-api-container
+    name: stacks-devnet-api
     image: hirosystems/stacks-devnet-api:latest
     imagePullPolicy: Always
     ports:
@@ -58,13 +58,13 @@ spec:
   volumes:
     - name: config-volume
       configMap:
-        name: stacks-devnet-api-conf
+        name: stacks-devnet-api
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: stacks-devnet-api-service
+  name: stacks-devnet-api
   namespace: devnet
 spec:
   ports:


### PR DESCRIPTION
Downstream pods are now renamed, so proxied requests have a different route.
 - `stacks-node` is now `stacks-blockchain`
 - `stacks-api` is now `stacks-blockchain-api`

Fixes #61 