### PR TITLE
feat: status page at `GET /` and `GET /api/v1/status` routes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
         run: |
           cargo install cargo-tarpaulin
           cargo --version
-          cargo tarpaulin --out lcov
+          cargo tarpaulin --out lcov --features k8s_tests
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ tower-test = "0.4.0"
 test-case = "3.1.0"
 rand = "0.8.5"
 serial_test = "2.0.0"
+
+[features]
+k8s_tests = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use stacks_devnet_api::api_config::ApiConfig;
 use stacks_devnet_api::responder::Responder;
 use stacks_devnet_api::routes::{
     get_standardized_path_parts, handle_check_devnet, handle_delete_devnet, handle_get_devnet,
-    handle_new_devnet, handle_try_proxy_service, API_PATH,
+    handle_get_status, handle_new_devnet, handle_try_proxy_service, API_PATH,
 };
 use stacks_devnet_api::{Context, StacksDevnetApiK8sManager};
 use std::env;
@@ -82,6 +82,9 @@ async fn handle_request(
 
     if method == &Method::OPTIONS {
         return responder.ok();
+    }
+    if method == &Method::GET && (path == "/" || path == &format!("{API_PATH}status")) {
+        return handle_get_status(responder, ctx).await;
     }
     let auth_header = auth_config
         .auth_header

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,8 +78,7 @@ async fn handle_request(
         )
     });
     let headers = request.headers().clone();
-    let responder = Responder::new(http_response_config, headers.clone()).unwrap();
-
+    let responder = Responder::new(http_response_config, headers.clone(), ctx.clone()).unwrap();
     if method == &Method::OPTIONS {
         return responder.ok();
     }

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -117,6 +117,18 @@ impl Responder {
         self._respond(StatusCode::OK, "Ok".into())
     }
 
+    pub fn ok_with_json(&self, body: Body) -> Result<Response<Body>, Infallible> {
+        match self
+            .response_builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", "application/json")
+            .body(body)
+        {
+            Ok(r) => Ok(r),
+            Err(e) => self.err_internal(format!("failed to send response: {}", e.to_string())),
+        }
+    }
+
     pub fn err_method_not_allowed(&self, body: String) -> Result<Response<Body>, Infallible> {
         self._respond(StatusCode::METHOD_NOT_ALLOWED, body)
     }

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -8,26 +8,39 @@ use hyper::{
 };
 use std::convert::Infallible;
 
-use crate::api_config::ResponderConfig;
+use crate::{api_config::ResponderConfig, Context};
 
-#[derive(Default)]
 pub struct Responder {
     allowed_origins: Vec<String>,
     allowed_methods: Vec<String>,
     allowed_headers: String,
     headers: HeaderMap<HeaderValue>,
+    ctx: Context,
 }
 
+impl Default for Responder {
+    fn default() -> Self {
+        Responder {
+            allowed_origins: Vec::default(),
+            allowed_methods: Vec::default(),
+            allowed_headers: String::default(),
+            headers: HeaderMap::default(),
+            ctx: Context::empty(),
+        }
+    }
+}
 impl Responder {
     pub fn new(
         config: ResponderConfig,
         headers: HeaderMap<HeaderValue>,
+        ctx: Context,
     ) -> Result<Responder, String> {
         Ok(Responder {
             allowed_origins: config.allowed_origins.unwrap_or_default(),
             allowed_methods: config.allowed_methods.unwrap_or_default(),
             allowed_headers: config.allowed_headers.unwrap_or("*".to_string()),
             headers,
+            ctx,
         })
     }
 

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -107,7 +107,10 @@ impl Responder {
     }
 
     pub fn respond(&self, code: u16, body: String) -> Result<Response<Body>, Infallible> {
-        self._respond(StatusCode::from_u16(code).unwrap(), body)
+        self._respond(
+            StatusCode::from_u16(code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+            body,
+        )
     }
 
     pub fn ok(&self) -> Result<Response<Body>, Infallible> {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -60,12 +60,7 @@ pub async fn handle_get_devnet(
 ) -> Result<Response<Body>, Infallible> {
     match k8s_manager.get_devnet_info(&network).await {
         Ok(devnet_info) => match serde_json::to_vec(&devnet_info) {
-            Ok(body) => Ok(responder
-                .response_builder()
-                .status(StatusCode::OK)
-                .header("Content-Type", "application/json")
-                .body(Body::from(body))
-                .unwrap()),
+            Ok(body) => responder.ok_with_json(Body::from(body)),
             Err(e) => {
                 let msg = format!(
                     "failed to form response body: NAMESPACE: {}, ERROR: {}",

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,5 +1,6 @@
 use hiro_system_kit::slog;
-use hyper::{Body, Client, Request, Response, StatusCode, Uri};
+use hyper::{Body, Client, Request, Response, Uri};
+use serde_json::json;
 use std::{convert::Infallible, str::FromStr};
 
 use crate::{
@@ -8,6 +9,27 @@ use crate::{
     responder::Responder,
     Context, StacksDevnetApiK8sManager,
 };
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const PRJ_NAME: &str = env!("CARGO_PKG_NAME");
+
+pub async fn handle_get_status(
+    responder: Responder,
+    ctx: Context,
+) -> Result<Response<Body>, Infallible> {
+    let version_info = format!("{PRJ_NAME} v{VERSION}");
+    let version_info = json!({ "version": version_info });
+    let version_info = match serde_json::to_vec(&version_info) {
+        Ok(v) => v,
+        Err(e) => {
+            let msg = format!("failed to parse version info: {}", e.to_string());
+            ctx.try_log(|logger| slog::error!(logger, "{}", msg));
+            return responder.err_internal(msg);
+        }
+    };
+    let body = Body::from(version_info);
+    responder.ok_with_json(body)
+}
 
 pub async fn handle_new_devnet(
     request: Request<Body>,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -399,7 +399,7 @@ fn responder_allows_configuring_allowed_origins() {
     };
     let mut headers = HeaderMap::new();
     headers.append("ORIGIN", HeaderValue::from_str("example.com").unwrap());
-    let responder = Responder::new(config, headers).unwrap();
+    let responder = Responder::new(config, headers, Context::empty()).unwrap();
     let builder = responder.response_builder();
     let built_headers = builder.headers_ref().unwrap();
     assert_eq!(built_headers.get(ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(), "*");

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -120,7 +120,7 @@ enum TestBody {
 #[test_case("/api/v1/network/{namespace}/stacks-node/v2/info/", Method::GET, None, true => using assert_failed_proxy; "proxies requests to downstream nodes")]
 #[serial_test::serial]
 #[tokio::test]
-#[cfg_attr(not(feature = "redis_tests"), ignore)]
+#[cfg_attr(not(feature = "k8s_tests"), ignore)]
 async fn it_responds_to_valid_requests_with_deploy(
     mut request_path: &str,
     method: Method,
@@ -188,7 +188,7 @@ async fn it_responds_to_valid_requests_with_deploy(
 #[test_case("/api/v1/network/{namespace}", Method::HEAD, true => is equal_to (StatusCode::NOT_FOUND, "not found".to_string()); "404 for network HEAD request to non-existing network")]
 #[test_case("/api/v1/network/{namespace}/stacks-node/v2/info/", Method::GET, true => using assert_not_all_assets_exist_err; "404 for proxy requests to downstream nodes of non-existing network")]
 #[tokio::test]
-#[cfg_attr(not(feature = "redis_tests"), ignore)]
+#[cfg_attr(not(feature = "k8s_tests"), ignore)]
 async fn it_responds_to_valid_requests(
     mut request_path: &str,
     method: Method,
@@ -425,7 +425,7 @@ fn responder_allows_configuring_allowed_origins() {
 
 #[serial_test::serial]
 #[tokio::test]
-#[cfg_attr(not(feature = "redis_tests"), ignore)]
+#[cfg_attr(not(feature = "k8s_tests"), ignore)]
 async fn namespace_prefix_config_prepends_header() {
     let (k8s_manager, ctx) = get_k8s_manager().await;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -120,6 +120,7 @@ enum TestBody {
 #[test_case("/api/v1/network/{namespace}/stacks-node/v2/info/", Method::GET, None, true => using assert_failed_proxy; "proxies requests to downstream nodes")]
 #[serial_test::serial]
 #[tokio::test]
+#[cfg_attr(not(feature = "redis_tests"), ignore)]
 async fn it_responds_to_valid_requests_with_deploy(
     mut request_path: &str,
     method: Method,
@@ -187,6 +188,7 @@ async fn it_responds_to_valid_requests_with_deploy(
 #[test_case("/api/v1/network/{namespace}", Method::HEAD, true => is equal_to (StatusCode::NOT_FOUND, "not found".to_string()); "404 for network HEAD request to non-existing network")]
 #[test_case("/api/v1/network/{namespace}/stacks-node/v2/info/", Method::GET, true => using assert_not_all_assets_exist_err; "404 for proxy requests to downstream nodes of non-existing network")]
 #[tokio::test]
+#[cfg_attr(not(feature = "redis_tests"), ignore)]
 async fn it_responds_to_valid_requests(
     mut request_path: &str,
     method: Method,
@@ -423,6 +425,7 @@ fn responder_allows_configuring_allowed_origins() {
 
 #[serial_test::serial]
 #[tokio::test]
+#[cfg_attr(not(feature = "redis_tests"), ignore)]
 async fn namespace_prefix_config_prepends_header() {
     let (k8s_manager, ctx) = get_k8s_manager().await;
 


### PR DESCRIPTION
### Description

This PR makes the `GET /` and `GET /api/v1/status` available, and responds with a status object:
```JSON
{ "version": "stacks-devnet-api v0.1.0" }
```

Note, this route is available _before_ any auth headers are checked.
Fixes #59 

---

### Checklist

- [X] All tests pass
- [X] Tests added in this PR (if applicable)

