### PR TITLE
feat: allow configuring k8s context with env var

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
         run: |
           cargo install cargo-tarpaulin
           cargo --version
-          KUBE_CONTEXT="k3d-kube" cargo tarpaulin --out lcov --features k8s_tests
+          cargo tarpaulin --out lcov --features k8s_tests
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
         run: |
           cargo install cargo-tarpaulin
           cargo --version
-          cargo tarpaulin --out lcov --features k8s_tests
+          KUBE_CONTEXT="k3d-kube" cargo tarpaulin --out lcov --features k8s_tests
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,10 +121,14 @@ impl StacksDevnetApiK8sManager {
                     cluster: Some(context),
                     user: None,
                 };
-                let client_config = Config::from_kubeconfig(&kube_config)
-                    .await
-                    .expect("could not create kube client config");
-                Client::try_from(client_config).expect("could not create kube client")
+                let client_config =
+                    Config::from_kubeconfig(&kube_config)
+                        .await
+                        .unwrap_or_else(|e| {
+                            panic!("could not create kube client config: {}", e.to_string())
+                        });
+                Client::try_from(client_config)
+                    .unwrap_or_else(|e| panic!("could not create kube client: {}", e.to_string()))
             }
             None => Client::try_default()
                 .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,11 +104,18 @@ impl StacksDevnetApiK8sManager {
         let context = match env::var("KUBE_CONTEXT") {
             Ok(context) => Some(context),
             Err(_) => {
-                // if no context is supplied and we're running a test,
-                // specify a local context so we don't deploy a bunch of
-                // test assets
                 if cfg!(test) {
-                    Some(format!("kind-kind"))
+                    let is_ci = match env::var("GITHUB_ACTIONS") {
+                        Ok(is_ci) => is_ci == format!("true"),
+                        Err(_) => false,
+                    };
+                    if is_ci {
+                        None
+                    } else {
+                        // ensures that if no context is supplied and we're running
+                        // tests locally, we deploy to the local kind cluster
+                        Some(format!("kind-kind"))
+                    }
                 } else {
                     None
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::{convert::Infallible, net::SocketAddr};
 #[tokio::main]
 async fn main() {
     const HOST: &str = "0.0.0.0";
-    const PORT: &str = "8477";
+    const PORT: &str = "8478";
     let endpoint: String = HOST.to_owned() + ":" + PORT;
     let addr: SocketAddr = endpoint.parse().expect("Could not parse ip:port.");
 
@@ -24,7 +24,7 @@ async fn main() {
         logger: Some(logger),
         tracer: false,
     };
-    let k8s_manager = StacksDevnetApiK8sManager::default(&ctx).await;
+    let k8s_manager = StacksDevnetApiK8sManager::new(&ctx).await;
     let config_path = match env::var("CONFIG_PATH") {
         Ok(path) => path,
         Err(_) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::{convert::Infallible, net::SocketAddr};
 #[tokio::main]
 async fn main() {
     const HOST: &str = "0.0.0.0";
-    const PORT: &str = "8478";
+    const PORT: &str = "8477";
     let endpoint: String = HOST.to_owned() + ":" + PORT;
     let addr: SocketAddr = endpoint.parse().expect("Could not parse ip:port.");
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -54,7 +54,7 @@ async fn get_k8s_manager() -> (StacksDevnetApiK8sManager, Context) {
     let logger = hiro_system_kit::log::setup_logger();
     let _guard = hiro_system_kit::log::setup_global_logger(logger.clone());
     let ctx = Context::empty();
-    let k8s_manager = StacksDevnetApiK8sManager::default(&ctx).await;
+    let k8s_manager = StacksDevnetApiK8sManager::new(&ctx).await;
     (k8s_manager, ctx)
 }
 
@@ -269,7 +269,7 @@ async fn get_mock_k8s_manager() -> (StacksDevnetApiK8sManager, Context) {
     let logger = hiro_system_kit::log::setup_logger();
     let _guard = hiro_system_kit::log::setup_global_logger(logger.clone());
     let ctx = Context::empty();
-    let k8s_manager = StacksDevnetApiK8sManager::new(mock_service, "default", &ctx).await;
+    let k8s_manager = StacksDevnetApiK8sManager::from_service(mock_service, "default", &ctx).await;
     (k8s_manager, ctx)
 }
 


### PR DESCRIPTION
### Description

Previously, the hosts default context was always used for starting the API and running tests. This can potentially be dangerous, especially if a user is running tests locally and forgets that production contexts are currently set as their default.

This PR allows configuring the context with the `KUBE_CONTEXT` environment variable. If no context is set, the host's default context is still used, **unless running tests**, in which case the context `kind-kind` is used.


---

### Checklist

- [X] All tests pass
- [ ] Tests added in this PR (if applicable)

