### PR TITLE
chore: add label to all configmaps

### DIFF
--- a/templates/configmaps/bitcoind.template.yaml
+++ b/templates/configmaps/bitcoind.template.yaml
@@ -5,3 +5,6 @@ kind: ConfigMap
 metadata:
   name: bitcoind
   namespace: "{namespace}"
+  labels:
+    app.kubernetes.io/managed-by: stacks-devnet-api
+

--- a/templates/configmaps/chain-coord-deployment-plan.template.yaml
+++ b/templates/configmaps/chain-coord-deployment-plan.template.yaml
@@ -5,3 +5,5 @@ kind: ConfigMap
 metadata:
   name: deployment-plan
   namespace: "{namespace}"
+  labels:
+    app.kubernetes.io/managed-by: stacks-devnet-api

--- a/templates/configmaps/chain-coord-devnet.template.yaml
+++ b/templates/configmaps/chain-coord-devnet.template.yaml
@@ -7,3 +7,6 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
+    app.kubernetes.io/instance: "{user_id}"
+    app.kubernetes.io/name: devnet
+    app.kubernetes.io/component: devnet

--- a/templates/configmaps/chain-coord-devnet.template.yaml
+++ b/templates/configmaps/chain-coord-devnet.template.yaml
@@ -5,3 +5,5 @@ kind: ConfigMap
 metadata:
   name: devnet
   namespace: "{namespace}"
+  labels:
+    app.kubernetes.io/managed-by: stacks-devnet-api

--- a/templates/configmaps/chain-coord-project-dir.template.yaml
+++ b/templates/configmaps/chain-coord-project-dir.template.yaml
@@ -5,3 +5,5 @@ kind: ConfigMap
 metadata:
   name: project-dir
   namespace: "{namespace}"
+  labels:
+    app.kubernetes.io/managed-by: stacks-devnet-api

--- a/templates/configmaps/chain-coord-project-dir.template.yaml
+++ b/templates/configmaps/chain-coord-project-dir.template.yaml
@@ -7,3 +7,6 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
+    app.kubernetes.io/instance: "{user_id}"
+    app.kubernetes.io/name: project-dir
+    app.kubernetes.io/component: project-dir

--- a/templates/configmaps/chain-coord-project-manifest.template.yaml
+++ b/templates/configmaps/chain-coord-project-manifest.template.yaml
@@ -7,3 +7,6 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
+    app.kubernetes.io/instance: "{user_id}"
+    app.kubernetes.io/name: project-manifest
+    app.kubernetes.io/component: project-manifest

--- a/templates/configmaps/chain-coord-project-manifest.template.yaml
+++ b/templates/configmaps/chain-coord-project-manifest.template.yaml
@@ -5,3 +5,5 @@ kind: ConfigMap
 metadata:
   name: project-manifest
   namespace: "{namespace}"
+  labels:
+    app.kubernetes.io/managed-by: stacks-devnet-api

--- a/templates/configmaps/stacks-blockchain-api-pg.template.yaml
+++ b/templates/configmaps/stacks-blockchain-api-pg.template.yaml
@@ -5,3 +5,5 @@ kind: ConfigMap
 metadata:
   name: stacks-blockchain-api-pg
   namespace: "{namespace}"
+  labels:
+    app.kubernetes.io/managed-by: stacks-devnet-api

--- a/templates/configmaps/stacks-blockchain-api-pg.template.yaml
+++ b/templates/configmaps/stacks-blockchain-api-pg.template.yaml
@@ -7,3 +7,6 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
+    app.kubernetes.io/instance: "{user_id}"
+    app.kubernetes.io/name: stacks-blockchain-api-pg
+    app.kubernetes.io/component: stacks-blockchain-api-pg

--- a/templates/configmaps/stacks-blockchain-api.template.yaml
+++ b/templates/configmaps/stacks-blockchain-api.template.yaml
@@ -7,3 +7,6 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
+    app.kubernetes.io/instance: "{user_id}"
+    app.kubernetes.io/name: stacks-blockchain-api
+    app.kubernetes.io/component: stacks-blockchain-api

--- a/templates/configmaps/stacks-blockchain-api.template.yaml
+++ b/templates/configmaps/stacks-blockchain-api.template.yaml
@@ -5,3 +5,5 @@ kind: ConfigMap
 metadata:
   name: stacks-blockchain-api
   namespace: "{namespace}"
+  labels:
+    app.kubernetes.io/managed-by: stacks-devnet-api

--- a/templates/configmaps/stacks-blockchain.template.yaml
+++ b/templates/configmaps/stacks-blockchain.template.yaml
@@ -7,3 +7,6 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
+    app.kubernetes.io/instance: "{user_id}"
+    app.kubernetes.io/name: stacks-blockchain
+    app.kubernetes.io/component: stacks-blockchain

--- a/templates/configmaps/stacks-blockchain.template.yaml
+++ b/templates/configmaps/stacks-blockchain.template.yaml
@@ -5,3 +5,5 @@ kind: ConfigMap
 metadata:
   name: stacks-blockchain
   namespace: "{namespace}"
+  labels:
+    app.kubernetes.io/managed-by: stacks-devnet-api


### PR DESCRIPTION
### Description

The platform cleanup cronjob needs to also delete configmaps in order for the devnet-api to handle a relaunch properly.  I'm able to delete all the configmaps if I list each one out but using labels to ensure I catch everything and any new configmaps in the future would be a better approach.  

