### PR TITLE
fix: removing untemplated labels

### DIFF
--- a/templates/configmaps/bitcoind.template.yaml
+++ b/templates/configmaps/bitcoind.template.yaml
@@ -7,4 +7,5 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
-
+    app.kubernetes.io/name: bitcoind
+    app.kubernetes.io/component: bitcoind

--- a/templates/configmaps/chain-coord-deployment-plan.template.yaml
+++ b/templates/configmaps/chain-coord-deployment-plan.template.yaml
@@ -7,3 +7,5 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
+    app.kubernetes.io/name: deployment-plan
+    app.kubernetes.io/component: deployment-plan

--- a/templates/configmaps/chain-coord-devnet.template.yaml
+++ b/templates/configmaps/chain-coord-devnet.template.yaml
@@ -7,6 +7,5 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
-    app.kubernetes.io/instance: "{user_id}"
     app.kubernetes.io/name: devnet
     app.kubernetes.io/component: devnet

--- a/templates/configmaps/chain-coord-project-dir.template.yaml
+++ b/templates/configmaps/chain-coord-project-dir.template.yaml
@@ -7,6 +7,5 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
-    app.kubernetes.io/instance: "{user_id}"
     app.kubernetes.io/name: project-dir
     app.kubernetes.io/component: project-dir

--- a/templates/configmaps/chain-coord-project-manifest.template.yaml
+++ b/templates/configmaps/chain-coord-project-manifest.template.yaml
@@ -7,6 +7,5 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
-    app.kubernetes.io/instance: "{user_id}"
     app.kubernetes.io/name: project-manifest
     app.kubernetes.io/component: project-manifest

--- a/templates/configmaps/stacks-blockchain-api-pg.template.yaml
+++ b/templates/configmaps/stacks-blockchain-api-pg.template.yaml
@@ -7,6 +7,5 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
-    app.kubernetes.io/instance: "{user_id}"
     app.kubernetes.io/name: stacks-blockchain-api-pg
     app.kubernetes.io/component: stacks-blockchain-api-pg

--- a/templates/configmaps/stacks-blockchain-api.template.yaml
+++ b/templates/configmaps/stacks-blockchain-api.template.yaml
@@ -7,6 +7,5 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
-    app.kubernetes.io/instance: "{user_id}"
     app.kubernetes.io/name: stacks-blockchain-api
     app.kubernetes.io/component: stacks-blockchain-api

--- a/templates/configmaps/stacks-blockchain.template.yaml
+++ b/templates/configmaps/stacks-blockchain.template.yaml
@@ -7,6 +7,5 @@ metadata:
   namespace: "{namespace}"
   labels:
     app.kubernetes.io/managed-by: stacks-devnet-api
-    app.kubernetes.io/instance: "{user_id}"
     app.kubernetes.io/name: stacks-blockchain
     app.kubernetes.io/component: stacks-blockchain


### PR DESCRIPTION
### Description

- removing untemplated labels for now.  the `{{user_id}}` label is not critical in the configmaps as they are all the same for every  devnet deployment

the devnet-api not accounting for and replacing the '{[user_id}}' in the configmaps will break deployments.  '{{user_id}}' will be treated as literal which is violates constraints.  see [here](https://github.com/hirosystems/stacks-devnet-api/actions/runs/6725165115/job/18279334508#step:11:708) 