### PR TITLE
feat: track last request time for each user id

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -37,7 +37,7 @@ impl StacksDevnetConfig {
     pub fn to_validated_config(
         self,
         user_id: &str,
-        ctx: Context,
+        ctx: &Context,
     ) -> Result<ValidatedStacksDevnetConfig, DevNetError> {
         let context = format!(
             "failed to validate config for NAMESPACE: {}",
@@ -232,7 +232,7 @@ mod tests {
         let _guard = hiro_system_kit::log::setup_global_logger(logger.clone());
         let ctx = Context::empty();
         let validated_config = template
-            .to_validated_config(user_id, ctx)
+            .to_validated_config(user_id, &ctx)
             .unwrap_or_else(|e| panic!("config validation test failed: {}", e.message));
 
         let expected_project_manifest = read_file("src/tests/fixtures/project-manifest.yaml");
@@ -278,7 +278,7 @@ mod tests {
         template.network_manifest.devnet = None;
         let user_id = template.clone().namespace;
         template
-            .to_validated_config(&user_id, ctx)
+            .to_validated_config(&user_id, &ctx)
             .unwrap_or_else(|e| panic!("config validation test failed: {}", e.message));
     }
 
@@ -287,7 +287,7 @@ mod tests {
         let template = get_template_config("src/tests/fixtures/stacks-devnet-config.json");
         let namespace = template.namespace.clone();
         let user_id = "wrong";
-        match template.to_validated_config(user_id, Context::empty()) {
+        match template.to_validated_config(user_id, &Context::empty()) {
             Ok(_) => {
                 panic!("config validation with non-matching user_id should have been rejected")
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1876,7 +1876,7 @@ impl StacksDevnetApiK8sManager {
                     namespace.map_left(|del| {
                         assert_eq!(del.name_any(), namespace_str);
                         self.ctx
-                            .try_log(|logger| slog::error!(logger, "Deleting namespace started"));
+                            .try_log(|logger| slog::info!(logger, "Deleting namespace started"));
                     });
                     Ok(())
                 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -65,10 +65,11 @@ fn get_template_config(use_nakamoto: bool) -> StacksDevnetConfig {
 async fn get_k8s_manager() -> (StacksDevnetApiK8sManager, Context) {
     let logger = hiro_system_kit::log::setup_logger();
     let _guard = hiro_system_kit::log::setup_global_logger(logger.clone());
-    let ctx = Context {
-        logger: Some(logger),
-        tracer: false,
-    };
+    let ctx = Context::empty();
+    // let ctx = Context {
+    //     logger: Some(logger),
+    //     tracer: false,
+    // };
     let k8s_manager = StacksDevnetApiK8sManager::new(&ctx).await;
     (k8s_manager, ctx)
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -367,7 +367,7 @@ async fn it_tracks_requests_time_for_user() {
     // wait some time so we have time elapsed since last request
     sleep(Duration::new(1, 0));
 
-    let secs_after_first_get = {
+    let secs_after_first_get1 = {
         let info =
             get_devnet_info(&namespace, k8s_manager.clone(), request_store.clone(), &ctx).await;
         // time should have elapsed since our last request
@@ -382,7 +382,7 @@ async fn it_tracks_requests_time_for_user() {
     };
 
     // confirm time has elapsed since our last request
-    {
+    let secs_after_first_get2 = {
         let info = get_devnet_info(
             &namespace2,
             k8s_manager.clone(),
@@ -390,8 +390,10 @@ async fn it_tracks_requests_time_for_user() {
             &ctx,
         )
         .await;
-        assert!(info.metadata.secs_since_last_request > 0);
-    }
+        let secs_after_first_get = info.metadata.secs_since_last_request;
+        assert!(secs_after_first_get > 0);
+        secs_after_first_get
+    };
 
     // send a request that should reset the time since last request
     {
@@ -417,7 +419,7 @@ async fn it_tracks_requests_time_for_user() {
     {
         let info =
             get_devnet_info(&namespace, k8s_manager.clone(), request_store.clone(), &ctx).await;
-        assert!(secs_after_first_get > info.metadata.secs_since_last_request);
+        assert!(secs_after_first_get1 > info.metadata.secs_since_last_request);
     }
 
     // and verify that the time since the last request wasn't updated for our other namespace
@@ -429,7 +431,7 @@ async fn it_tracks_requests_time_for_user() {
             &ctx,
         )
         .await;
-        assert!(info.metadata.secs_since_last_request >= secs_after_first_get);
+        assert!(info.metadata.secs_since_last_request >= secs_after_first_get2);
     }
 
     // clear out the block store to emulate a service restart


### PR DESCRIPTION

This tracks the last request time for each user id in an in-memory store. 

Any successful devnet creations will insert an entry into the store for the user id.

Any requests to `GET /api/v1/network/{namespace}` will now include this in the response:
```JSON
"metadata": {
  "secs_since_last_request": 500
}
```
`HEAD/GET  /api/v1/network/{namespace}` requests will not update the last request time in the store, since this endpoint is used internally to get the health of a devnet.

However, if the devnet API is ever restarted, it will lose the request store. So, if an entry does not exist for a devnet, and that devnet receives a successful `GET` request, an entry will be inserted for that user.

Any requests that are forwarded to the underlying api/stacks node/bitcoin node do update the last request time for that user id.

`DELETE /api/v1/network/{namespace}` requests will delete the entry for that user.
