### PR TITLE
fix: pass faucet address env var to stacks network

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1506,6 +1506,7 @@ impl StacksDevnetApiK8sManager {
             ("V2_POX_MIN_AMOUNT_USTX".into(), "90000000260".into()),
             ("NODE_ENV".into(), "production".into()),
             ("STACKS_API_LOG_LEVEL".into(), "debug".into()),
+            ("FAUCET_PRIVATE_KEY".into(), config.devnet_config.faucet_secret_key_hex.clone().into()),
         ]);
         self.deploy_configmap(
             StacksDevnetConfigmap::StacksBlockchainApi,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1506,7 +1506,7 @@ impl StacksDevnetApiK8sManager {
             ("V2_POX_MIN_AMOUNT_USTX".into(), "90000000260".into()),
             ("NODE_ENV".into(), "production".into()),
             ("STACKS_API_LOG_LEVEL".into(), "debug".into()),
-            ("FAUCET_PRIVATE_KEY".into(), config.devnet_config.faucet_secret_key_hex.clone().into()),
+            ("FAUCET_PRIVATE_KEY".into(), config.devnet_config.faucet_secret_key_hex.clone()),
         ]);
         self.deploy_configmap(
             StacksDevnetConfigmap::StacksBlockchainApi,


### PR DESCRIPTION
### Description

The faucet address should be passed in env vars when starting a stacks network, like here: https://github.com/hirosystems/clarinet/blob/b58cca5dce734bd9433d389e466fd5ea6018460f/components/stacks-network/src/orchestrator.rs#L1893

Closes https://github.com/hirosystems/platform/issues/1184