### PR TITLE
chore: use new argocd annotations to track resources

### DIFF
--- a/templates/ci/stacks-devnet-api.template.yaml
+++ b/templates/ci/stacks-devnet-api.template.yaml
@@ -34,8 +34,7 @@ roleRef:
   name: stacks-devnet-api
   apiGroup: rbac.authorization.k8s.io
 
----  
-
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -78,4 +77,3 @@ spec:
   selector:
     name: stacks-devnet-api
   type: NodePort
-

--- a/templates/configmaps/bitcoind.template.yaml
+++ b/templates/configmaps/bitcoind.template.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: bitcoind
     app.kubernetes.io/component: bitcoind
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd

--- a/templates/configmaps/chain-coord-deployment-plan.template.yaml
+++ b/templates/configmaps/chain-coord-deployment-plan.template.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: deployment-plan
     app.kubernetes.io/component: deployment-plan
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd

--- a/templates/configmaps/chain-coord-devnet.template.yaml
+++ b/templates/configmaps/chain-coord-devnet.template.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: devnet
     app.kubernetes.io/component: devnet
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd

--- a/templates/configmaps/chain-coord-project-dir.template.yaml
+++ b/templates/configmaps/chain-coord-project-dir.template.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: project-dir
     app.kubernetes.io/component: project-dir
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd

--- a/templates/configmaps/chain-coord-project-manifest.template.yaml
+++ b/templates/configmaps/chain-coord-project-manifest.template.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: project-manifest
     app.kubernetes.io/component: project-manifest
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd

--- a/templates/configmaps/stacks-blockchain-api-pg.template.yaml
+++ b/templates/configmaps/stacks-blockchain-api-pg.template.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-blockchain-api-pg
     app.kubernetes.io/component: stacks-blockchain-api-pg
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd

--- a/templates/configmaps/stacks-blockchain-api.template.yaml
+++ b/templates/configmaps/stacks-blockchain-api.template.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-blockchain-api
     app.kubernetes.io/component: stacks-blockchain-api
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd

--- a/templates/configmaps/stacks-blockchain.template.yaml
+++ b/templates/configmaps/stacks-blockchain.template.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-blockchain
     app.kubernetes.io/component: stacks-blockchain
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd

--- a/templates/configmaps/stacks-signer-0.template.yaml
+++ b/templates/configmaps/stacks-signer-0.template.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-signer-0
     app.kubernetes.io/component: stacks-signer-0
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd

--- a/templates/configmaps/stacks-signer-1.template.yaml
+++ b/templates/configmaps/stacks-signer-1.template.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-signer-1
     app.kubernetes.io/component: stacks-signer-1
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd

--- a/templates/deployments/bitcoind-chain-coordinator.template.yaml
+++ b/templates/deployments/bitcoind-chain-coordinator.template.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: bitcoind-chain-coordinator
     argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
   name: bitcoind-chain-coordinator
   namespace: "{namespace}"
 spec:
@@ -24,6 +26,8 @@ spec:
         app.kubernetes.io/instance: "{user_id}"
         app.kubernetes.io/managed-by: stacks-devnet-api
         app.kubernetes.io/name: bitcoind-chain-coordinator
+      annotations:
+        argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
     spec:
       affinity:
         nodeAffinity:

--- a/templates/deployments/stacks-blockchain.template.yaml
+++ b/templates/deployments/stacks-blockchain.template.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-blockchain
     argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
   name: stacks-blockchain
   namespace: "{namespace}"
 spec:
@@ -24,6 +26,8 @@ spec:
         app.kubernetes.io/instance: "{user_id}"
         app.kubernetes.io/managed-by: stacks-devnet-api
         app.kubernetes.io/name: stacks-blockchain
+      annotations:
+        argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
     spec:
       affinity:
         nodeAffinity:

--- a/templates/services/bitcoind-chain-coordinator.template.yaml
+++ b/templates/services/bitcoind-chain-coordinator.template.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: bitcoind-chain-coordinator
     argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
   name: bitcoind-chain-coordinator
   namespace: "{namespace}"
 spec:

--- a/templates/services/stacks-blockchain-api.template.yaml
+++ b/templates/services/stacks-blockchain-api.template.yaml
@@ -6,7 +6,8 @@ metadata:
     app.kubernetes.io/instance: "{user_id}"
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-blockchain-api
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
   name: stacks-blockchain-api
   namespace: "{namespace}"
 spec:

--- a/templates/services/stacks-blockchain.template.yaml
+++ b/templates/services/stacks-blockchain.template.yaml
@@ -6,7 +6,8 @@ metadata:
     app.kubernetes.io/instance: "{user_id}"
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-blockchain
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
   name: stacks-blockchain
   namespace: "{namespace}"
 spec:

--- a/templates/services/stacks-signer-0.template.yaml
+++ b/templates/services/stacks-signer-0.template.yaml
@@ -6,7 +6,8 @@ metadata:
     app.kubernetes.io/instance: "{user_id}"
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-signer-0
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
   name: stacks-signer-0
   namespace: "{namespace}"
 spec:

--- a/templates/services/stacks-signer-1.template.yaml
+++ b/templates/services/stacks-signer-1.template.yaml
@@ -6,7 +6,8 @@ metadata:
     app.kubernetes.io/instance: "{user_id}"
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-signer-1
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
   name: stacks-signer-1
   namespace: "{namespace}"
 spec:

--- a/templates/stateful-sets/stacks-blockchain-api.template.yaml
+++ b/templates/stateful-sets/stacks-blockchain-api.template.yaml
@@ -6,7 +6,8 @@ metadata:
     app.kubernetes.io/instance: "{user_id}"
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-blockchain-api
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
   name: stacks-blockchain-api
   namespace: "{namespace}"
 spec:
@@ -25,6 +26,8 @@ spec:
         app.kubernetes.io/instance: "{user_id}"
         app.kubernetes.io/managed-by: stacks-devnet-api
         app.kubernetes.io/name: stacks-blockchain-api
+      annotations:
+        argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
     spec:
       affinity:
         nodeAffinity:

--- a/templates/stateful-sets/stacks-signer-0.template.yaml
+++ b/templates/stateful-sets/stacks-signer-0.template.yaml
@@ -6,7 +6,8 @@ metadata:
     app.kubernetes.io/instance: "{user_id}"
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-signer-0
-    argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
   name: stacks-signer-0
   namespace: "{namespace}"
 spec:
@@ -25,6 +26,8 @@ spec:
         app.kubernetes.io/instance: "{user_id}"
         app.kubernetes.io/managed-by: stacks-devnet-api
         app.kubernetes.io/name: stacks-signer-0
+      annotations:
+        argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
     spec:
       affinity:
         nodeAffinity:

--- a/templates/stateful-sets/stacks-signer-1.template.yaml
+++ b/templates/stateful-sets/stacks-signer-1.template.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: stacks-devnet-api
     app.kubernetes.io/name: stacks-signer-1
     argocd.argoproj.io/instance: platform-user-resources.platform
+  annotations:
+    argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
   name: stacks-signer-1
   namespace: "{namespace}"
 spec:
@@ -25,6 +27,8 @@ spec:
         app.kubernetes.io/instance: "{user_id}"
         app.kubernetes.io/managed-by: stacks-devnet-api
         app.kubernetes.io/name: stacks-signer-1
+      annotations:
+        argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd
     spec:
       affinity:
         nodeAffinity:


### PR DESCRIPTION
This replaces all occurrences of the **label** 
`argocd.argoproj.io/instance: platform-user-resources.platform` 

and replaces it with an **annotation** of: 
`argocd.argoproj.io/tracking-id: platform-user-resources.platform:apps/Deployment:{user_id}/argo-cd`